### PR TITLE
Create guide

### DIFF
--- a/guide
+++ b/guide
@@ -1,0 +1,170 @@
+```markdown
+# Techstars Startup Weekend PAI Palooza - Bay Area: Participants Weekend Guide 🎉
+
+Startup Weekend is meant to empower entrepreneurs who are learning the basics of founding startups and launching successful ventures. It is a 54-hour event that brings together developers, designers, marketers, product managers, and startup enthusiasts to share ideas, form teams, build products, and launch startups. Here's a breakdown of a typical Startup Weekend:
+
+## 1. Friday Evening:
+
+### Pitches 🎤
+Participants pitch their startup ideas in a one-minute format. This is followed by a round of voting to select the top ideas that will be worked on over the weekend.
+
+### Team Formation 👥
+Participants choose which idea they want to work on and form teams around those ideas.
+
+## 2. Saturday:
+
+### Workshops and Mentorship 🛠️
+Teams get down to business by brainstorming, developing business plans, and creating prototypes. Throughout the day, they receive guidance from mentors who are experienced entrepreneurs, investors, or industry experts.
+
+### Market Validation 📊
+Teams are encouraged to go out and validate their ideas by talking to potential customers.
+
+**5:00PM - Register to Pitch your project on Sunday**: [Register Here](https://docs.google.com/forms/d/e/1FAIpQLSfp7bkvJTqBlK9Il6zBPZI5nIEsyhL1MYyRf85aPF6WmkUfQQ/viewform)
+
+## 3. Sunday:
+
+### Final Touches and Pitch Preparation 📝
+Teams work on finalizing their product, preparing their pitch, and rehearsing their presentations.
+
+### Final Presentations 🎬
+In the afternoon, teams present their final products and business models to a panel of judges. These presentations are typically five minutes long, 2 minutes to pitch, followed by 3 mins for Q&A from the judges.
+
+### Awards and Networking 🏆
+Judges select the winning teams based on criteria such as validation, execution, and business model. The event concludes with awards and networking.
+
+For a detailed schedule of events: [Event Schedule](https://lu.ma/2svuyacm)
+
+---
+
+## Key Aspects of This Weekend:
+
+### Collaborative Learning 🤝
+It’s an immersive experience where participants learn by doing and from each other.
+
+### Diverse Participation 🌍
+People from various professional backgrounds and skill sets come together to form teams, which fosters diverse and innovative solutions.
+
+### Mentorship 🎓
+Access to mentors provides participants with insights and advice from experienced professionals.
+
+### Networking 🔗
+While you’re here, you have the opportunity to connect with like-minded individuals, potential co-founders, and future collaborators.
+
+### Pro Tip 💡
+Print or save a picture on your phone of Your LinkedIn QR Code, and have it accessible to scan to smoothly connect with other participants.
+
+#### How to find or scan a QR code in LinkedIn:
+- Open the app on your phone
+- Tap on the search bar to open it
+- On the right side of the search field is an icon that indicates scanning for a QR code, tap on that
+- Your QR code should appear, including a link to save it to your phone picture gallery.
+- There is also a tab to ‘Scan’ so you can scan another person’s LinkedIn QR code.
+
+---
+
+## General Information 📋
+
+### Important Links:
+- **Discord**: [Join Here](https://discord.gg/tAC7EZ3JKf)
+- **Devpost**: [Submit Here](http://devpost.com/paipalooza)
+- **Event Schedule**: [View Schedule](https://lu.ma/2svuyacm)
+- **WhatsApp Group**: [Join Here](https://chat.whatsapp.com/JY7HNAQVlb3BzJDbcKO5kv)
+
+### Contact Information:
+- For communication with sponsors, mentors, other hackers, and general questions: Use the corresponding Discord channels such as #ask-mentors and #hackathon-help
+- Help desk: The PAI Palooza Team will be roaming through the event, and outside in the lobby of the host facility. Feel free to ask any questions! You can also email [help@paipalooza.com](mailto:help@paipalooza.com) if you have any questions.
+- Key Contacts: Toby Morning, Karsten Wade, Jaymes Hines, Ayori Selassie, Jerome Palencia, Deep Rastogi, Allen Smith
+- Code of Conduct: [View Here](https://github.com/PAIPalooza/policies/blob/main/code-of-conduct.md)
+- **Emergencies**: If you are experiencing a true emergency, please dial 911 immediately, and have someone alert the PAI Palooza Team if possible.
+- Emergency services: 911
+
+### Venue Info & Map 📍
+- **Googleplex, Mountain View, CA**
+- [Event Schedule](https://lu.ma/2svuyacm)
+
+### Transportation 🚗
+- **Coming from the airport?** The best way to get to the Googleplex in Mountain View is by rideshare or taxi. Public transportation (Caltrans) options are also available.
+- **Need parking?** There is lots of parking available around the hackathon venue. We highly recommend the Googleplex parking facilities. Additional parking is available nearby.
+
+### Participant Checklist ✅
+- Laptop + Charger
+- Monitor & Cables
+- Powerstrip
+- Headphones
+- Refillable Water Bottle
+- Optional snacks/meals
+- Money for onsite food or emergencies
+- Jacket
+- Deodorant & ToothBrush (Please!)
+
+---
+
+## Collaborating 🤝
+- You can join or form teams from in-person and remote participants. There are no requirements on the tools and processes you use, but here are some recommendations and things available:
+- For finding teams to join or people to join your team, use Discord.
+- FounderWay.AI is a tool that leads you through a Lean Canvas and Lean Startup approach, learn more at the Saturday morning workshop.
+- We have created a WhatsApp Group you can use and create rooms within. This is a good way to easily connect with mentors, too. [Join Here](https://chat.whatsapp.com/JY7HNAQVlb3BzJDbcKO5kv)
+- You can similarly use Signal, Telegram, etc.
+
+### Mentoring 🧑‍🏫
+- **I need help! What should I do?**
+  - Discord is the main form of communication with the mentors. Here is where you will be able to create issues and ask the mentors for help.
+  - To interact and connect with mentors, please be active on the #ask-mentors channel.
+  - **@YourUserName has requested a mentor**
+    - Team: [Name of Teams Project]
+    - Issue: [ISSUE]
+    - Location: [In Person Event / Virtual Participant]
+
+For any follow-up questions, you can reply in thread by hovering over the message and selecting the Create Thread or View Thread button shown below:
+
+From there, the mentor and you can coordinate to either get the answer to your question in Discord if it is quick, or have them head to your teams table to assist you further in person. For a virtual mentor or connection, use the WhatsApp group or whichever team messaging app you chose.
+
+### Judging 🏅
+Startup Weekends are judged based on a set of criteria that evaluates various aspects of the teams' projects.
+
+Judging at Startup Weekends is usually done by a panel of judges who come from diverse backgrounds, including entrepreneurs, investors, industry experts, and academics. They bring different perspectives to the evaluation process, ensuring a well-rounded assessment of each team's project. The goal is to identify teams that have the potential to develop their ideas into successful, scalable businesses.
+
+#### 1. Validation:
+- **Customer Validation**: Did the team validate their idea by talking to real users, customers, or experts? This involves demonstrating that there is a real demand for the product or service.
+- **Market Research**: Has the team conducted thorough research on their market and potential competitors?
+
+#### 2. Execution and Design:
+- **Prototype**: How functional and developed is the prototype? Judges look for a working demo that shows the product's core features.
+- **User Experience (UX) and Design**: Is the product intuitive, user-friendly, and aesthetically pleasing? Good design and user experience are crucial for product adoption.
+
+#### 3. Business Model:
+- **Revenue Model**: Does the team have a clear and viable plan for generating revenue? This includes understanding the target market, pricing strategy, and sales channels.
+- **Scalability**: Can the business model scale effectively? Judges assess whether the idea has the potential to grow and serve a larger market.
+
+### Judging Criteria:
+
+#### 1. Customer Validation:
+- **Interviews and Surveys**: Evidence of interviews, surveys, or other forms of direct engagement with potential customers.
+- **Insights and Feedback**: Analysis of the feedback received and how it influenced the product development.
+
+#### 2. Execution and Design:
+- **MVP (Minimum Viable Product)**: Quality and functionality of the MVP. Is it a working product or a well-developed prototype?
+- **Technical Implementation**: Quality of the technical implementation. This includes code quality, use of technology, and overall functionality.
+- **Design and UX**: Quality of the design and user interface. Judges look for a product that is easy to use and visually appealing.
+
+#### 3. Business Model:
+- **Value Proposition**: Clarity of the value proposition. Does the team clearly articulate the problem they are solving and the benefits of their solution?
+- **Market Size and Opportunity**: Understanding of the market size and opportunity. Judges look for evidence that the market is large enough to support a viable business.
+-
+
+ **Revenue Strategy**: Viability of the revenue strategy. This includes pricing, sales channels, and customer acquisition plans.
+
+#### 4. Overall Impact:
+- **Innovation and Creativity**: Originality and creativity of the idea. Judges look for innovative solutions that stand out.
+- **Social Impact**: Potential social or environmental impact of the solution. Judges consider whether the product can make a positive difference in society.
+
+**NOTE:** The exact criteria and weighting may vary depending on the specific Startup Weekend event and the preferences of the judging panel.
+
+---
+
+## See you all there! 🤩
+
+For more information and updates, make sure to check our event page and join the discussions on Discord.
+
+**Good luck to all participants! Let's create something amazing together! 🚀**
+```


### PR DESCRIPTION
Added comprehensive participant guide for Techstars Startup Weekend PAI Palooza - Bay Area

- Included detailed event schedule with key activities for Friday, Saturday, and Sunday
- Provided essential information on workshops, mentorship, team formation, and final presentations
- Added important links for registration, Discord, Devpost, WhatsApp group, and event schedule
- Outlined judging criteria for customer validation, execution and design, business model, and overall impact
- Included practical tips for participants, venue information, and contact details for assistance

This guide will help participants navigate the weekend effectively and maximize their experience.